### PR TITLE
Add envVars to CompositeAnnotation

### DIFF
--- a/annotations/component-annotations/src/main/java/io/ap4k/component/ComponentHandler.java
+++ b/annotations/component-annotations/src/main/java/io/ap4k/component/ComponentHandler.java
@@ -20,9 +20,11 @@ import io.ap4k.Handler;
 import io.ap4k.Resources;
 import io.ap4k.component.config.CompositeConfig;
 import io.ap4k.component.config.EditableCompositeConfig;
+import io.ap4k.component.decorator.AddEnvToComponent;
 import io.ap4k.component.decorator.AddRuntimeToComponent;
 import io.ap4k.config.ConfigKey;
 import io.ap4k.config.Configuration;
+import io.ap4k.config.Env;
 import io.ap4k.config.KubernetesConfig;
 
 public class ComponentHandler implements Handler<CompositeConfig> {
@@ -55,6 +57,9 @@ public class ComponentHandler implements Handler<CompositeConfig> {
     String type = config.getAttribute(RUNTIME_TYPE);
     if (type != null) {
       resources.decorateCustom(COMPONENT,new AddRuntimeToComponent(type));
+    }
+    for (Env env : config.getEnvVars()) {
+      resources.decorateCustom(COMPONENT, new AddEnvToComponent(env));
     }
   }
 

--- a/annotations/component-annotations/src/main/java/io/ap4k/component/annotation/CompositeApplication.java
+++ b/annotations/component-annotations/src/main/java/io/ap4k/component/annotation/CompositeApplication.java
@@ -18,6 +18,7 @@ package io.ap4k.component.annotation;
 
 
 import io.ap4k.component.model.DeploymentType;
+import io.ap4k.annotation.Env;
 import io.ap4k.config.KubernetesConfig;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
@@ -40,11 +41,9 @@ public @interface CompositeApplication {
 
   boolean exposeService() default false;
 
+  Env[] envVars() default {};
+
   /*
-
-    Env[] envVars() default {};
-
-    ServiceCatalogInstance[] instances();
-
+  ServiceCatalogInstance[] instances();
   */
 }

--- a/examples/component-example/src/main/java/io/ap4k/examples/component/Main.java
+++ b/examples/component-example/src/main/java/io/ap4k/examples/component/Main.java
@@ -18,13 +18,14 @@
 
 package io.ap4k.examples.component;
 
+import io.ap4k.annotation.Env;
 import io.ap4k.annotation.KubernetesApplication;
 import io.ap4k.component.annotation.CompositeApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @KubernetesApplication
-@CompositeApplication
+@CompositeApplication(envVars = @Env(name = "key1", value = "val1"))
 @SpringBootApplication
 public class Main {
 


### PR DESCRIPTION
- Fix issue #39 
- Add envVars to CompositeAnnotation
- Issues discovered: **EnvVar is added twice - see issue 28** AND **runtime doesn't appear anymore**
```
  spec:
    deploymentMode: "innerloop"
    exposeService: false
    image: []
    env:
    - name: "key1"
      value: "val1"
    - name: "key1"
      value: "val1"
```
