### PR TITLE
Add missing method withExposeService

### DIFF
--- a/annotations/component-annotations/src/main/java/io/ap4k/component/ComponentHandler.java
+++ b/annotations/component-annotations/src/main/java/io/ap4k/component/ComponentHandler.java
@@ -79,6 +79,7 @@ public class ComponentHandler implements Handler<CompositeConfig> {
       .endMetadata()
       .withNewSpec()
       .withDeploymentMode(DeploymentType.innerloop)
+      .withExposeService(config.isExposeService())
       .endSpec()
       .build();
   }

--- a/examples/component-example/src/main/java/io/ap4k/examples/component/Main.java
+++ b/examples/component-example/src/main/java/io/ap4k/examples/component/Main.java
@@ -23,7 +23,7 @@ import io.ap4k.component.annotation.CompositeApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@CompositeApplication(envVars = @Env(name = "key1", value = "val1"))
+@CompositeApplication(name = "hello-spring-boot", exposeService = true, envVars = @Env(name = "key1", value = "val1"))
 @SpringBootApplication
 public class Main {
 


### PR DESCRIPTION
- Add missing method `withExposeService` to the componentHandler. 
- Enrich the `Component example` with `name` and `exposService` fields