### PR TITLE
Introduce prometheus annotations

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -35,6 +35,7 @@ limitations under the License.
     <module>servicecatalog-annotations</module>
     <module>component-annotations</module>
     <module>docker-annotations</module>
+    <module>prometheus-annotations</module>
   </modules>
 
 </project>

--- a/annotations/prometheus-annotations/pom.xml
+++ b/annotations/prometheus-annotations/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>annotations</artifactId>
+    <groupId>io.ap4k</groupId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.ap4k</groupId>
+  <artifactId>prometheus-annotations</artifactId>
+
+ <name>AP4K :: Annotations :: Prometheus</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.ap4k</groupId>
+      <artifactId>ap4k-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>builder-annotations</artifactId>
+    </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>${version.junit-platform}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <version>${version.junit-platform}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <annotationProcessors>
+            <processor>io.sundr.builder.internal.processor.BuildableProcessor</processor>
+          </annotationProcessors>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven-shade-plugin}</version>
+        <executions>
+          <execution>
+            <id>annotation</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>annotations</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <includes>
+                    <include>io/ap4k/servicecatalog/annotation/**</include>
+                  </includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+          <execution>
+            <id>processor</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>processors</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <includes>
+                    <include>io/ap4k/prometheus/adapt/**</include>
+                    <include>io/ap4k/prometheus/config/**</include>
+                    <include>io/ap4k/prometheus/processor/**</include>
+                    <include>io/ap4k/prometheus/handler/**</include>
+                    <include>META-INF/services/javax.annotation.processing.Processor</include>
+                  </includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/annotation/EnableServiceMonitor.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/annotation/EnableServiceMonitor.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+package io.ap4k.prometheus.annotation;
+
+import io.ap4k.kubernetes.config.Configuration;
+import io.sundr.builder.annotations.Adapter;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Pojo;
+
+@Buildable(builderPackage = "io.ap4k.deps.kubernetes.api.builder")
+@Pojo(name = "ServiceMonitorConfig", mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(name = "ServiceMonitorConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
+public @interface EnableServiceMonitor {
+  String port() default "http";
+  String path() default "/metics";
+  int interval() default 10;
+  boolean honorLabels() default false;
+}

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/apt/ServiceMonitorAnnotationProcessor.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/apt/ServiceMonitorAnnotationProcessor.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * 
-**/
-package io.ap4k.docker.apt;
+ **/
+package io.ap4k.prometheus.apt;
 
-import io.ap4k.docker.registrar.EnableDockerBuildRegistrar;
+
 import io.ap4k.processor.AbstractAnnotationProcessor;
-import io.ap4k.doc.Description;
+import io.ap4k.prometheus.generator.ServiceMonitorGenerator;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -28,12 +28,10 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import java.util.Set;
 
-@Description("Register a docker build hook.")
-@SupportedAnnotationTypes("io.ap4k.docker.annotation.EnableDockerBuild")
+@SupportedAnnotationTypes({"io.ap4k.prometheus.annotation.EnableServiceMonitor"})
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
-public class DockerBuildAnnotationProcessor extends AbstractAnnotationProcessor implements EnableDockerBuildRegistrar {
+public class ServiceMonitorAnnotationProcessor extends AbstractAnnotationProcessor implements ServiceMonitorGenerator {
 
-  @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     if  (roundEnv.processingOver()) {
       session.close();

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/decorator/EndpointPathDecorator.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/decorator/EndpointPathDecorator.java
@@ -1,0 +1,37 @@
+package io.ap4k.prometheus.decorator;
+
+import io.ap4k.deps.kubernetes.api.builder.TypedVisitor;
+import io.ap4k.kubernetes.decorator.Decorator;
+import io.ap4k.prometheus.model.EndpointBuilder;
+import io.ap4k.prometheus.model.ServiceMonitorBuilder;
+
+/**
+ * A {@link Decorator} that will set the endpoint path on the {@link io.ap4k.prometheus.model.Endpoint} that matches the port,
+ * inside the {@link io.ap4k.prometheus.model.ServiceMonitor} that matches the name.
+ */
+public class EndpointPathDecorator extends Decorator<ServiceMonitorBuilder> {
+
+  private final String name;
+  private final String port;
+  private final String path;
+
+  public EndpointPathDecorator(String name, String port, String path) {
+    this.name = name;
+    this.port = port;
+    this.path = path;
+  }
+
+  @Override
+  public void visit(ServiceMonitorBuilder serviceMonitor) {
+    if (name.equals(serviceMonitor.getMetadata().getName())) {
+      serviceMonitor.accept(new TypedVisitor<EndpointBuilder>() {
+        @Override
+        public void visit(EndpointBuilder endpoint) {
+         if (port.equals(endpoint.getPort())) {
+           endpoint.withPath(path);
+         }
+        }
+      });
+    }
+  }
+}

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/generator/ServiceMonitorGenerator.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/generator/ServiceMonitorGenerator.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.ap4k.prometheus.generator;
+
+import io.ap4k.Generator;
+import io.ap4k.WithSession;
+import io.ap4k.config.ConfigurationSupplier;
+import io.ap4k.prometheus.adapter.ServiceMonitorConfigAdapter;
+import io.ap4k.prometheus.annotation.EnableServiceMonitor;
+import io.ap4k.prometheus.config.ServiceMonitorConfig;
+import io.ap4k.prometheus.config.ServiceMonitorConfigBuilder;
+import io.ap4k.prometheus.handler.ServiceMonitorHandler;
+
+import javax.lang.model.element.Element;
+import java.util.Map;
+
+public interface ServiceMonitorGenerator extends Generator, WithSession {
+
+  @Override
+  default void add(Map map) {
+    on(new ConfigurationSupplier<>(ServiceMonitorConfigAdapter.newBuilder(propertiesMap(map, EnableServiceMonitor.class))));
+  }
+
+  @Override
+  default void add(Element element) {
+    EnableServiceMonitor serviceMonitor = element.getAnnotation(EnableServiceMonitor.class);
+    on(serviceMonitor != null
+      ? new ConfigurationSupplier<>(ServiceMonitorConfigAdapter.newBuilder(serviceMonitor))
+      : new ConfigurationSupplier<>(new ServiceMonitorConfigBuilder()));
+  }
+
+  default void on(ConfigurationSupplier<ServiceMonitorConfig> config) {
+    session.configurators().add(config);
+    session.handlers().add(new ServiceMonitorHandler(session.resources()));
+  }
+}

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/handler/ServiceMonitorHandler.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/handler/ServiceMonitorHandler.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+package io.ap4k.prometheus.handler;
+
+import io.ap4k.Handler;
+import io.ap4k.Resources;
+import io.ap4k.kubernetes.config.Configuration;
+import io.ap4k.prometheus.config.EditableServiceMonitorConfig;
+import io.ap4k.prometheus.config.ServiceMonitorConfig;
+import io.ap4k.prometheus.model.ServiceMonitorBuilder;
+
+public class ServiceMonitorHandler implements Handler<ServiceMonitorConfig> {
+
+  private final Resources resources;
+
+  public ServiceMonitorHandler(Resources resources) {
+    this.resources = resources;
+  }
+
+  @Override
+  public int order() {
+    return 350;
+  }
+
+  @Override
+  public void handle(ServiceMonitorConfig config) {
+    resources.add(new ServiceMonitorBuilder()
+      .withNewMetadata()
+      .withName(resources.getName())
+      .withLabels(resources.getLabels())
+      .endMetadata()
+      .withNewSpec()
+      .withNewSelector()
+      .addToMatchLabels(resources.getLabels())
+      .endSelector()
+      .addNewEndpoint()
+      .withPort(config.getPort())
+      .withNewPath(config.getPath())
+      .withInterval(config.getInterval() + "s")
+      .withHonorLabels(config.isHonorLabels())
+      .endEndpoint()
+      .endSpec()
+      .build());
+  }
+
+  @Override
+  public boolean canHandle(Class<? extends Configuration> type) {
+    return type.equals(ServiceMonitorConfig.class) || type.equals(EditableServiceMonitorConfig.class);
+  }
+}

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/model/Endpoint.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/model/Endpoint.java
@@ -1,0 +1,63 @@
+package io.ap4k.prometheus.model;
+
+import io.ap4k.deps.jackson.annotation.JsonProperty;
+import io.ap4k.deps.kubernetes.api.model.Doneable;
+import io.ap4k.deps.kubernetes.api.model.ObjectMeta;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.ap4k.deps.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"), refs = @BuildableReference(ObjectMeta.class))
+public class Endpoint {
+
+  @JsonProperty("port")
+  String port;
+
+  @JsonProperty("path")
+  String path;
+
+  @JsonProperty("interval")
+  String interval;
+
+  @JsonProperty("honorLabels")
+  boolean honorLabels;
+
+  public Endpoint(String port, String path, String interval, boolean honorLabels) {
+    this.port = port;
+    this.path = path;
+    this.interval = interval;
+    this.honorLabels = honorLabels;
+  }
+
+  public String getPort() {
+    return port;
+  }
+
+  public void setPort(String port) {
+    this.port = port;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getInterval() {
+    return interval;
+  }
+
+  public void setInterval(String interval) {
+    this.interval = interval;
+  }
+
+  public boolean isHonorLabels() {
+    return honorLabels;
+  }
+
+  public void setHonorLabels(boolean honorLabels) {
+    this.honorLabels = honorLabels;
+  }
+}

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/model/ServiceMonitor.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/model/ServiceMonitor.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.ap4k.prometheus.model;
+
+import io.ap4k.deps.jackson.annotation.JsonInclude;
+import io.ap4k.deps.jackson.annotation.JsonProperty;
+import io.ap4k.deps.jackson.annotation.JsonPropertyOrder;
+import io.ap4k.deps.jackson.databind.annotation.JsonDeserialize;
+import io.ap4k.deps.javax.validation.Valid;
+import io.ap4k.deps.javax.validation.constraints.NotNull;
+import io.ap4k.deps.kubernetes.api.model.Doneable;
+import io.ap4k.deps.kubernetes.api.model.HasMetadata;
+import io.ap4k.deps.kubernetes.api.model.LabelSelector;
+import io.ap4k.deps.kubernetes.api.model.ObjectMeta;
+import io.ap4k.deps.kubernetes.api.model.validators.CheckObjectMeta;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+      "kind",
+      "metadata",
+      "spec",
+      })
+      @JsonDeserialize(using = io.ap4k.deps.jackson.databind.JsonDeserializer.None.class)
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.ap4k.deps.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"), refs = {@BuildableReference(ObjectMeta.class), @BuildableReference(LabelSelector.class)})
+public class ServiceMonitor implements HasMetadata {
+
+  /**
+   *
+   * (Required)
+   *
+   */
+  @NotNull
+  @JsonProperty("apiVersion")
+  private String apiVersion = "monitoring.coreos.com/v1";
+  /**
+   *
+   * (Required)
+   *
+   */
+  @NotNull
+  @JsonProperty("kind")
+  private String kind = "ServiceMonitor";
+  /**
+   *
+   *
+   */
+  @JsonProperty("metadata")
+  @Valid
+  @CheckObjectMeta(regexp = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", max = 253)
+  private ObjectMeta metadata;
+  /**
+   *
+   *
+   */
+  @JsonProperty("spec")
+  @Valid
+  private ServiceMonitorSpec spec;
+
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+  public ServiceMonitor() {
+  }
+
+  public ServiceMonitor(String apiVersion, String kind, ObjectMeta metadata, ServiceMonitorSpec spec, Map<String, Object> additionalProperties) {
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+    this.metadata = metadata;
+    this.spec = spec;
+    this.additionalProperties = additionalProperties;
+  }
+
+  @Override
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  @Override
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  @Override
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  @Override
+  public ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public void setMetadata(ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  public ServiceMonitorSpec getSpec() {
+    return spec;
+  }
+
+  public void setSpec(ServiceMonitorSpec spec) {
+    this.spec = spec;
+  }
+
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+    this.additionalProperties = additionalProperties;
+  }
+}

--- a/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/model/ServiceMonitorSpec.java
+++ b/annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/model/ServiceMonitorSpec.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+package io.ap4k.prometheus.model;
+
+import io.ap4k.deps.jackson.annotation.JsonProperty;
+import io.ap4k.deps.javax.validation.Valid;
+import io.ap4k.deps.kubernetes.api.model.Doneable;
+import io.ap4k.deps.kubernetes.api.model.LabelSelector;
+import io.ap4k.deps.kubernetes.api.model.ObjectMeta;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import java.util.List;
+
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.ap4k.deps.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"), refs = @BuildableReference(ObjectMeta.class))
+public class ServiceMonitorSpec {
+
+  @JsonProperty("selector")
+  @Valid
+  private LabelSelector selector;
+
+  @JsonProperty("endpoints")
+  @Valid
+  List<Endpoint> endpoints;
+
+  public ServiceMonitorSpec(LabelSelector selector, List<Endpoint> endpoints) {
+    this.selector = selector;
+    this.endpoints = endpoints;
+  }
+
+  public LabelSelector getSelector() {
+    return selector;
+  }
+
+  public void setSelector(LabelSelector selector) {
+    this.selector = selector;
+  }
+
+  public List<Endpoint> getEndpoints() {
+    return endpoints;
+  }
+
+  public void setEndpoints(List<Endpoint> endpoints) {
+    this.endpoints = endpoints;
+  }
+}

--- a/annotations/prometheus-annotations/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/annotations/prometheus-annotations/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.ap4k.prometheus.apt.ServiceMonitorAnnotationProcessor

--- a/core/src/main/java/io/ap4k/AbstractKubernetesHandler.java
+++ b/core/src/main/java/io/ap4k/AbstractKubernetesHandler.java
@@ -45,6 +45,7 @@ import io.ap4k.kubernetes.decorator.AddServiceDecorator;
 import io.ap4k.kubernetes.decorator.ApplyImagePullPolicyDecorator;
 import io.ap4k.kubernetes.decorator.ApplyReplicasDecorator;
 import io.ap4k.kubernetes.decorator.ApplyServiceAccountDecorator;
+import io.ap4k.utils.Labels;
 
 import java.util.Arrays;
 
@@ -71,6 +72,7 @@ public abstract class AbstractKubernetesHandler<C extends KubernetesConfig> impl
     resources.setGroup(config.getGroup());
     resources.setName(config.getName());
     resources.setVersion(config.getVersion());
+    resources.setLabels(Labels.createLabels(config));
     Arrays.asList(config.getLabels()).forEach(l -> resources.addLabel(l));
   }
 
@@ -128,7 +130,7 @@ public abstract class AbstractKubernetesHandler<C extends KubernetesConfig> impl
     }
 
     if (config.getPorts().length > 0) {
-      resources.decorate(group, new AddServiceDecorator(config));
+      resources.decorate(group, new AddServiceDecorator(config, resources.getLabels()));
     }
 
     resources.decorate(group, new AddLivenessProbeDecorator(config.getName(), config.getLivenessProbe()));

--- a/core/src/main/java/io/ap4k/Resources.java
+++ b/core/src/main/java/io/ap4k/Resources.java
@@ -47,7 +47,7 @@ public class Resources {
   private final AtomicReference<String> group = new AtomicReference<>();
   private final AtomicReference<String> name = new AtomicReference<>();
   private final AtomicReference<String> version = new AtomicReference<>();
-  private final Set<Label> labels = new LinkedHashSet<>();
+  private final Map<String, String> labels = new HashMap<String, String>();
 
 
   /**
@@ -187,9 +187,14 @@ public class Resources {
   }
 
   public void addLabel(Label label) {
-    this.labels.add(label);
+    this.labels.put(label.getKey(), label.getValue());
   }
+
+  public void setLabels(Map<String, String> labels) {
+    labels.entrySet().stream().map(e -> new Label(e.getKey(), e.getValue())).forEach(l -> addLabel(l));
+  }
+
   public Map<String, String> getLabels() {
-    return labels.stream().collect(Collectors.toMap(Label::getKey, Label::getValue));
+    return labels;
   }
 }

--- a/core/src/main/java/io/ap4k/Session.java
+++ b/core/src/main/java/io/ap4k/Session.java
@@ -113,7 +113,7 @@ public class Session {
    * Close the session an get all resource groups.
    * @return A map of {@link KubernetesList} by group name.
    */
-  public Map<String, KubernetesList> generate() {
+  private Map<String, KubernetesList> generate() {
     if (generated.compareAndSet(false, true)) {
       closed.set(true);
       configurators.stream().forEach(c ->

--- a/core/src/main/java/io/ap4k/SessionWriter.java
+++ b/core/src/main/java/io/ap4k/SessionWriter.java
@@ -24,7 +24,8 @@ public interface SessionWriter extends WithProject {
    * @param session The target session.
    */
   default void write(Session session) {
-    Map<String, KubernetesList> resources = session.generate();
+    session.close();
+    Map<String, KubernetesList> resources = session.getGeneratedResources();
     Set<? extends Configuration> configurations = session.configurators().toSet();
     resources.forEach((g, l) -> write(g, l));
     configurations.forEach(c -> write(c));

--- a/core/src/main/java/io/ap4k/kubernetes/decorator/AddServiceDecorator.java
+++ b/core/src/main/java/io/ap4k/kubernetes/decorator/AddServiceDecorator.java
@@ -21,10 +21,12 @@ package io.ap4k.kubernetes.decorator;
 import io.ap4k.deps.kubernetes.api.model.KubernetesListBuilder;
 import io.ap4k.kubernetes.config.KubernetesConfig;
 import io.ap4k.deps.kubernetes.api.model.ServicePort;
+import io.ap4k.kubernetes.config.Label;
 import io.ap4k.kubernetes.config.Port;
 import io.ap4k.deps.kubernetes.api.model.ServicePortBuilder;
 import io.ap4k.deps.kubernetes.api.model.IntOrString;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 import io.ap4k.utils.Labels;
 import io.ap4k.doc.Description;
@@ -33,15 +35,18 @@ import io.ap4k.doc.Description;
 public class AddServiceDecorator extends Decorator<KubernetesListBuilder> {
 
   private final KubernetesConfig config;
+  private final Map<String, String> allLabels; //A combination of config and project labels.
 
-  public AddServiceDecorator(KubernetesConfig config) {
+  public AddServiceDecorator(KubernetesConfig config, Map<String, String> allLabels) {
     this.config = config;
+    this.allLabels = allLabels;
   }
 
   public void visit(KubernetesListBuilder list) {
     list.addNewServiceItem()
       .withNewMetadata()
       .withName(config.getName())
+      .withLabels(allLabels)
       .endMetadata()
       .withNewSpec()
       .withType(config.getServiceType().name())

--- a/core/src/main/java/io/ap4k/processor/AptWriter.java
+++ b/core/src/main/java/io/ap4k/processor/AptWriter.java
@@ -55,7 +55,8 @@ public class AptWriter implements SessionWriter, WithProject {
    * @param session The target session.
    */
   public void write(Session session) {
-    Map<String, KubernetesList> resources = session.generate();
+    session.close();
+    Map<String, KubernetesList> resources = session.getGeneratedResources();
     Set<? extends Configuration> configurations = session.configurators().toSet();
     resources.forEach((g, l) -> write(g, l));
     configurations.forEach(c -> write(c));

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,6 +26,7 @@
     <module>spring-boot-with-gradle-on-kubernetes-example</module>
     <module>spring-boot-with-gradle-on-openshift-example</module>
     <module>spring-boot-with-fmp-on-kubernetes-example</module>
+    <module>spring-boot-with-prometheus-on-kubernetes-example</module>
   </modules>
 
 

--- a/examples/spring-boot-with-prometheus-on-kubernetes-example/Dockerfile
+++ b/examples/spring-boot-with-prometheus-on-kubernetes-example/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8u171-alpine3.7
+RUN apk --no-cache add curl
+COPY target/*.jar spring-on-kubernetes-example.jar
+CMD java ${JAVA_OPTS} -jar spring-on-kubernetes-example.jar

--- a/examples/spring-boot-with-prometheus-on-kubernetes-example/pom.xml
+++ b/examples/spring-boot-with-prometheus-on-kubernetes-example/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>examples</artifactId>
+    <groupId>io.ap4k</groupId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.ap4k</groupId>
+  <artifactId>spring-boot-with-prometheus-on-kubernetes-example</artifactId>
+  <name>AP4K :: Examples :: Spring Boot with Prometheus on Kubernetes</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.1.0.RELEASE</version.spring-boot>
+    <version.micrometer>1.0.9</version.micrometer>
+    <version.fabric8-maven-plugin>3.5.42</version.fabric8-maven-plugin>
+  </properties>
+
+ <dependencies>
+    <dependency>
+      <groupId>io.ap4k</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+   <dependency>
+     <groupId>io.ap4k</groupId>
+     <artifactId>prometheus-annotations</artifactId>
+     <version>${project.version}</version>
+   </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>${version.micrometer}</version>
+    </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.ap4k</groupId>
+      <artifactId>kubernetes-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>build</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>fabric8-maven-plugin</artifactId>
+            <version>${version.fabric8-maven-plugin}</version>
+            <executions>
+              <execution>
+                <id>resources</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>resource</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>build</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/examples/spring-boot-with-prometheus-on-kubernetes-example/src/main/java/io/ap4k/example/sbonkubernetes/Main.java
+++ b/examples/spring-boot-with-prometheus-on-kubernetes-example/src/main/java/io/ap4k/example/sbonkubernetes/Main.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.ap4k.example.sbonkubernetes;
+
+import io.ap4k.docker.annotation.EnableDockerBuild;
+import io.ap4k.kubernetes.annotation.KubernetesApplication;
+import io.ap4k.prometheus.annotation.EnableServiceMonitor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@KubernetesApplication
+@EnableServiceMonitor
+@EnableDockerBuild
+@RestController
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/spring-boot-with-prometheus-on-kubernetes-example/src/main/resources/application.properties
+++ b/examples/spring-boot-with-prometheus-on-kubernetes-example/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+# for testing purposes make it available publicly
+management.endpoints.enabled-by-default=true
+management.endpoints.web.exposure.include=health,info,metrics,prometheus

--- a/frameworks/spring-boot/pom.xml
+++ b/frameworks/spring-boot/pom.xml
@@ -20,6 +20,19 @@
     </dependency>
 
     <dependency>
+      <groupId>io.ap4k</groupId>
+      <artifactId>prometheus-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>builder-annotations</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${version.junit-jupiter}</version>
@@ -59,8 +72,9 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
-          <!-- Disable annotation processing for ourselves. -->
-          <compilerArgument>-proc:none</compilerArgument>
+          <annotationProcessors>
+            <processor>io.sundr.builder.internal.processor.BuildableProcessor</processor>
+          </annotationProcessors>
         </configuration>
       </plugin>
     </plugins>

--- a/frameworks/spring-boot/src/main/java/io/ap4k/spring/config/SpringApplicationConfig.java
+++ b/frameworks/spring-boot/src/main/java/io/ap4k/spring/config/SpringApplicationConfig.java
@@ -1,0 +1,9 @@
+package io.ap4k.spring.config;
+
+import io.ap4k.kubernetes.config.Configuration;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+
+@Buildable(builderPackage = "io.ap4k.deps.kubernetes.api.builder", refs = @BuildableReference(Configuration.class))
+public class SpringApplicationConfig extends Configuration {
+}

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Stop wasting time editing xml, json and yml and customize the kubernetes manifes
 - Generates manifest via annotation processing
   - [Kubernetes](#kubernetes-annotations)
   - [Openshift](#openshift-annotations)
+  - [Prometheus](#prometheus-annotations)
   - [Service Catalog](#service-catalog-annotations)
   - [Component CRD](#component-annotations)
   - Istio
@@ -26,6 +27,7 @@ Stop wasting time editing xml, json and yml and customize the kubernetes manifes
   - Openshift 
     - [image streams](#integrating-with-s2i)
     - build configurations
+  - Prometheus
   - Service Catalog
     - service instances
     - inject bindings into pods
@@ -319,7 +321,33 @@ done either by `oc get bc` or by knowing the conventions used to read names from
 - [source to image example](examples/source-to-image-example)
 - [spring boot on openshift example](examples/spring-boot-on-openshift-example)
 - [spring boot with groovy on openshift example](examples/spring-boot-with-groovy-on-openshift-example)
-- [spring boot with gradle on openshift example](examples/spring-boot-with-gradle-on-openshift-example)
+- [spring boot with gradle on openshift example](examples/spring-boot-with-gradle-on-openshift-example) 
+
+### Prometheus annotations
+
+The [prometheus](https://prometheus.io/) annotation processor provides annotations for generating prometheus related resources.
+In particular it can generate [ServiceMonitor](annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/model/ServiceMonitor.java) which are used by the
+[Prometheus Operator](https://github.com/coreos/prometheus-operator) in order to configure [prometheus](https://prometheus.io/) to collect metrics from the target application.
+
+This is done with the use of [@EnableServiceMonitor](annotations/prometheus-annotations/src/main/java/io/ap4k/prometheus/annotation/EnableServiceMonitor.java) annotation.
+
+Here's an example:
+
+    import io.ap4k.kubernetes.annotation.KubernentesApplication;
+    import io.ap4k.prometheus.annotation.EnableServiceMonitor;
+
+    @KubernetesApplication
+    @EnableServiceMonitor(port = "http", path="/prometheus", interval=20)
+    public class Main {
+        public static void main(String[] args) {
+          //Your code goes here
+        }
+    }
+
+The annotation processor, will automatically configure the required selector and generate the ServiceMonitor.
+Note: Some of the framework integration modules, may further decorate the ServiceMonitor with framework specific configuration.
+For example, the Spring Boot module will decorate the monitor with the Spring Boot specific path, which is `/actuator/prometheus`.
+
 ### Service Catalog annotations
 The [services catalog](https://svc-cat.io) annotation processor is can be used in order to create [services catalog](https://svc-cat.io) resources for:
 


### PR DESCRIPTION
The goal of this pull request is to add intiial support for prometheus annotations. 
It introduced `EnableServiceMonitor` which will generate a ServiceMonitor for the application.

The service monitor requires the prometheus operator, in order to work. Once its created the operator will take care of monitoring the application.