### PR TITLE
feat: disable examples building by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn integration-test
+      - run: mvn integration-test -Pwith-examples
 
   OPENSHIFT_3_11:
     machine: true

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
     <module>core</module>
     <module>frameworks</module>
     <module>annotations</module>
-    <module>examples</module>
     <module>testing</module>
     <module>starters</module>
     <module>doc</module>
@@ -265,6 +264,18 @@
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
+    </profile>
+    <profile>
+      <id>with-examples</id>
+      <modules>
+        <module>core</module>
+        <module>frameworks</module>
+        <module>annotations</module>
+        <module>examples</module>
+        <module>testing</module>
+        <module>starters</module>
+        <module>doc</module>
+      </modules>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This is done because the examples don't respect -DskipTests