### PR TITLE
refactor: Extract GeneratorOptions into a separate module

### DIFF
--- a/annotations/generatoroptions-annotations/pom.xml
+++ b/annotations/generatoroptions-annotations/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2018 The original authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>annotations</artifactId>
+    <groupId>io.ap4k</groupId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.ap4k</groupId>
+  <artifactId>generatoroptions-annotations</artifactId>
+  <name>AP4K :: Annotations :: Generator Config</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.ap4k</groupId>
+      <artifactId>ap4k-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>builder-annotations</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <annotationProcessors>
+            <processor>io.sundr.builder.internal.processor.BuildableProcessor</processor>
+          </annotationProcessors>
+        </configuration>
+      </plugin>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven-shade-plugin}</version>
+        <executions>
+          <execution>
+            <id>annotation</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>annotations</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <includes>
+                    <include>io/ap4k/generatoroptions/annotation/**</include>
+                  </includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+          <execution>
+            <id>processor</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>processors</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <includes>
+                    <include>io/ap4k/generatorconfig/adapter/**</include>
+                    <include>io/ap4k/generatorconfig/config/**</include>
+                    <include>io/ap4k/generatorconfig/decorator/**</include>
+                    <include>io/ap4k/generatorconfig/handler/**</include>
+                    <include>io/ap4k/generatorconfig/processor/**</include>
+                    <include>META-INF/services/javax.annotation.processing.Processor</include>
+                  </includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/annotations/generatoroptions-annotations/src/main/java/io/ap4k/generatoroptions/annotation/GeneratorOptions.java
+++ b/annotations/generatoroptions-annotations/src/main/java/io/ap4k/generatoroptions/annotation/GeneratorOptions.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  **/
-package io.ap4k.annotation;
+package io.ap4k.generatoroptions.annotation;
 
 import io.ap4k.kubernetes.config.Configuration;
 import io.sundr.builder.annotations.Adapter;

--- a/annotations/generatoroptions-annotations/src/main/java/io/ap4k/generatoroptions/handler/GeneratorOptionsHandler.java
+++ b/annotations/generatoroptions-annotations/src/main/java/io/ap4k/generatoroptions/handler/GeneratorOptionsHandler.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  *
  **/
-package io.ap4k.handler;
+package io.ap4k.generatoroptions.handler;
 
 import io.ap4k.Ap4kException;
-import io.ap4k.Handler;
 import io.ap4k.Resources;
-import io.ap4k.config.EditableGeneratorConfig;
-import io.ap4k.config.GeneratorConfig;
+import io.ap4k.Handler;
+import io.ap4k.generatoroptions.config.EditableGeneratorConfig;
+import io.ap4k.generatoroptions.config.GeneratorConfig;
 import io.ap4k.deps.kubernetes.api.model.HasMetadata;
 import io.ap4k.deps.kubernetes.api.model.KubernetesList;
 import io.ap4k.deps.kubernetes.api.model.KubernetesResource;

--- a/annotations/generatoroptions-annotations/src/main/java/io/ap4k/generatoroptions/processor/GeneratorOptionsProcessor.java
+++ b/annotations/generatoroptions-annotations/src/main/java/io/ap4k/generatoroptions/processor/GeneratorOptionsProcessor.java
@@ -15,12 +15,13 @@
  *
  **/
 
-package io.ap4k.processor;
+package io.ap4k.generatoroptions.processor;
 
 import io.ap4k.WithSession;
-import io.ap4k.annotation.GeneratorOptions;
 import io.ap4k.doc.Description;
-import io.ap4k.handler.GeneratorOptionsHandler;
+import io.ap4k.generatoroptions.annotation.GeneratorOptions;
+import io.ap4k.generatoroptions.handler.GeneratorOptionsHandler;
+import io.ap4k.processor.AbstractAnnotationProcessor;
 import io.ap4k.utils.Strings;
 
 import javax.annotation.processing.RoundEnvironment;
@@ -35,7 +36,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 @Description("Processing generator options, which are used for customizing the generation process")
-@SupportedAnnotationTypes("io.ap4k.annotation.GeneratorOptions")
+@SupportedAnnotationTypes("io.ap4k.generatoroptions.annotation.GeneratorOptions")
 public class GeneratorOptionsProcessor extends AbstractAnnotationProcessor implements WithSession {
 
   private static final String INPUT_DIR = "ap4k.input.dir";

--- a/annotations/generatoroptions-annotations/src/main/resources/javax.annotation.processing.Processor
+++ b/annotations/generatoroptions-annotations/src/main/resources/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.ap4k.generatoroptions.processor.GeneratorOptionsProcessor

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -29,6 +29,7 @@ limitations under the License.
   <name>AP4K :: Annotations</name>
 
   <modules>
+    <module>generatoroptions-annotations</module>
     <module>kubernetes-annotations</module>
     <module>openshift-annotations</module>
     <module>servicecatalog-annotations</module>

--- a/core/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/core/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,0 @@
-io.ap4k.processor.GeneratorOptionsProcessor

--- a/examples/spring-boot-with-fmp-on-kubernetes-example/pom.xml
+++ b/examples/spring-boot-with-fmp-on-kubernetes-example/pom.xml
@@ -21,6 +21,11 @@
   </properties>
 
  <dependencies>
+   <dependency>
+     <groupId>io.ap4k</groupId>
+     <artifactId>generatoroptions-annotations</artifactId>
+     <version>${project.version}</version>
+   </dependency>
     <dependency>
       <groupId>io.ap4k</groupId>
       <artifactId>openshift-annotations</artifactId>

--- a/examples/spring-boot-with-fmp-on-kubernetes-example/src/main/java/io/ap4k/example/sbonkubernetes/Main.java
+++ b/examples/spring-boot-with-fmp-on-kubernetes-example/src/main/java/io/ap4k/example/sbonkubernetes/Main.java
@@ -17,7 +17,7 @@
 
 package io.ap4k.example.sbonkubernetes;
 
-import io.ap4k.annotation.GeneratorOptions;
+import io.ap4k.generatoroptions.annotation.GeneratorOptions;
 import io.ap4k.kubernetes.annotation.Label;
 import io.ap4k.openshift.annotation.EnableS2iBuild;
 import io.ap4k.openshift.annotation.OpenshiftApplication;

--- a/starters/kubernetes/kubernetes-spring-starter/pom.xml
+++ b/starters/kubernetes/kubernetes-spring-starter/pom.xml
@@ -15,6 +15,12 @@
     <!-- Annotations -->
     <dependency>
       <groupId>io.ap4k</groupId>
+      <artifactId>generatoroptions-annotations</artifactId>
+      <version>${project.version}</version>
+      <classifier>annotations</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.ap4k</groupId>
       <artifactId>docker-annotations</artifactId>
       <version>${project.version}</version>
       <classifier>annotations</classifier>

--- a/starters/kubernetes/kubernetes-thorntail-starter/pom.xml
+++ b/starters/kubernetes/kubernetes-thorntail-starter/pom.xml
@@ -15,6 +15,12 @@
     <!-- Annotations -->
     <dependency>
       <groupId>io.ap4k</groupId>
+      <artifactId>generatoroptions-annotations</artifactId>
+      <version>${project.version}</version>
+      <classifier>annotations</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.ap4k</groupId>
       <artifactId>docker-annotations</artifactId>
       <version>${project.version}</version>
       <classifier>annotations</classifier>

--- a/starters/openshift/openshift-spring-starter/pom.xml
+++ b/starters/openshift/openshift-spring-starter/pom.xml
@@ -15,6 +15,12 @@
     <!-- Annotations -->
     <dependency>
       <groupId>io.ap4k</groupId>
+      <artifactId>generatoroptions-annotations</artifactId>
+      <version>${project.version}</version>
+      <classifier>annotations</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.ap4k</groupId>
       <artifactId>openshift-annotations</artifactId>
       <version>${project.version}</version>
       <classifier>annotations</classifier>

--- a/starters/openshift/openshift-thorntail-starter/pom.xml
+++ b/starters/openshift/openshift-thorntail-starter/pom.xml
@@ -15,6 +15,12 @@
     <!-- Annotations -->
     <dependency>
       <groupId>io.ap4k</groupId>
+      <artifactId>generatoroptions-annotations</artifactId>
+      <version>${project.version}</version>
+      <classifier>annotations</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.ap4k</groupId>
       <artifactId>openshift-annotations</artifactId>
       <version>${project.version}</version>
       <classifier>annotations</classifier>


### PR DESCRIPTION
The fact that the module was in the core meant that it got executed
even when a project was only including the apt versions of annotations