### PR TITLE
fix: Rationalize the handling of Route

### DIFF
--- a/annotations/openshift-annotations/src/main/java/io/ap4k/openshift/decorator/AddRouteDecorator.java
+++ b/annotations/openshift-annotations/src/main/java/io/ap4k/openshift/decorator/AddRouteDecorator.java
@@ -44,7 +44,7 @@ public class AddRouteDecorator extends Decorator<KubernetesListBuilder> {
   public void visit(KubernetesListBuilder list) {
     Optional<Port> p = getHttpPort(config);
 
-    if (!p.isPresent()  || Strings.isNullOrEmpty(config.getHost())) {
+    if (!p.isPresent() || !config.isExposeRoute()) {
       return;
     }
 

--- a/examples/source-to-image-example/pom.xml
+++ b/examples/source-to-image-example/pom.xml
@@ -34,6 +34,7 @@ limitations under the License.
     <java.version>1.8</java.version>
 
     <version.spring-boot>2.1.0.RELEASE</version.spring-boot>
+    <version.awaitility>3.1.0</version.awaitility>
   </properties>
 
   <dependencies>
@@ -56,6 +57,12 @@ limitations under the License.
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${version.awaitility}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -69,6 +76,25 @@ limitations under the License.
             <goals>
               <goal>repackage</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/examples/source-to-image-example/src/main/java/io/ap4k/examples/s2i/Main.java
+++ b/examples/source-to-image-example/src/main/java/io/ap4k/examples/s2i/Main.java
@@ -17,12 +17,13 @@
 
 package io.ap4k.examples.s2i;
 
+import io.ap4k.kubernetes.annotation.Port;
 import io.ap4k.openshift.annotation.OpenshiftApplication;
 import io.ap4k.openshift.annotation.EnableS2iBuild;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@OpenshiftApplication
+@OpenshiftApplication(ports = {@Port(name = "http", containerPort = 8080)}, exposeRoute = true)
 @EnableS2iBuild
 @SpringBootApplication
 public class Main {

--- a/examples/source-to-image-example/src/test/java/io/ap4k/examples/s2i/SourceToImageIT.java
+++ b/examples/source-to-image-example/src/test/java/io/ap4k/examples/s2i/SourceToImageIT.java
@@ -1,0 +1,51 @@
+package io.ap4k.examples.s2i;
+
+import io.ap4k.deps.kubernetes.api.model.Pod;
+import io.ap4k.deps.kubernetes.client.KubernetesClient;
+import io.ap4k.deps.okhttp3.OkHttpClient;
+import io.ap4k.deps.okhttp3.Request;
+import io.ap4k.deps.okhttp3.Response;
+import io.ap4k.deps.openshift.api.model.Route;
+import io.ap4k.deps.openshift.client.OpenShiftClient;
+import io.ap4k.testing.annotation.Inject;
+import io.ap4k.testing.openshift.annotation.OpenshiftIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@OpenshiftIntegrationTest
+class SourceToImageIT {
+
+    @Inject
+    private KubernetesClient kubernetesClient;
+
+    @Inject
+    private Pod pod;
+
+    @Test
+    void testRoute() throws IOException {
+        String name = pod.getMetadata().getLabels().get("app");
+        assertNotNull(name);
+
+        Route route = kubernetesClient.adapt(OpenShiftClient.class).routes().withName(name).get();
+        assertNotNull(route);
+
+        String host = route.getSpec().getHost();
+        OkHttpClient client = new OkHttpClient();
+        Request request = new Request.Builder().get().url("http://" + host).build();
+
+        // we need to poll the Route since it is created long before the pod is actually up and running
+        await().pollInterval(5, TimeUnit.SECONDS).atMost(5, TimeUnit.MINUTES).until(() -> {
+            try {
+                Response response = client.newCall(request).execute();
+                return response.body().string().contains("Hello world");
+            } catch (Exception ignored) {
+                return false;
+            }
+        });
+    }
+}


### PR DESCRIPTION
There is no need to have `host` set in order for `Route` to work properly (FMP does not set it either or require the user to supply it)