### PR TITLE
Fix #198

### DIFF
--- a/core/src/main/java/io/ap4k/Configurators.java
+++ b/core/src/main/java/io/ap4k/Configurators.java
@@ -20,20 +20,24 @@ import io.ap4k.kubernetes.config.Configuration;
 import io.ap4k.config.ConfigurationSupplier;
 import io.ap4k.kubernetes.config.Configurator;
 
+import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class Configurators {
 
-  private final Set<ConfigurationSupplier<? extends Configuration>> suppliers = new LinkedHashSet<>();
+  private final Map<Type, ConfigurationSupplier<? extends Configuration>> suppliers = new ConcurrentHashMap<>();
   private final Set<Configurator> configurators = new HashSet<>();
 
   public void add(ConfigurationSupplier supplier) {
-    this.suppliers.add(supplier);
+    this.suppliers.put(supplier.getType(), supplier);
   }
   /**
    * Add a {@link Configurator}.
@@ -45,6 +49,7 @@ public class Configurators {
 
   public Stream<? extends Configuration> stream() {
     return suppliers
+      .values()
       .stream()
       .map(s -> s.configure(configurators).get());
   }
@@ -57,3 +62,4 @@ public class Configurators {
     return stream().filter(i -> type.isAssignableFrom(i.getClass())).map(i -> (C)i).findFirst();
   }
 }
+

--- a/core/src/main/java/io/ap4k/config/ConfigurationSupplier.java
+++ b/core/src/main/java/io/ap4k/config/ConfigurationSupplier.java
@@ -22,6 +22,8 @@ package io.ap4k.config;
 import io.ap4k.deps.kubernetes.api.builder.VisitableBuilder;
 import io.ap4k.kubernetes.config.Configurator;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.function.Supplier;
 
 /**
@@ -49,4 +51,12 @@ public class ConfigurationSupplier<C> implements Supplier<C> {
     builder.accept(configurator);
     return this;
   }
+
+  
+  public Type getType() {
+    Class builderClass = builder.getClass();
+    ParameterizedType parameterizedType = (ParameterizedType) builderClass.getGenericSuperclass();
+    return parameterizedType.getActualTypeArguments()[0];
+  }
+
 }

--- a/core/src/main/java/io/ap4k/processor/AptWriter.java
+++ b/core/src/main/java/io/ap4k/processor/AptWriter.java
@@ -86,7 +86,7 @@ public class AptWriter implements SessionWriter, WithProject {
         return new AbstractMap.SimpleEntry<>(yml.toString(), value);
       }
     } catch (IOException e) {
-      throw new RuntimeException("Error writing resources");
+      throw new RuntimeException("Error writing resources", e);
     }
   }
 
@@ -104,7 +104,7 @@ public class AptWriter implements SessionWriter, WithProject {
         return new AbstractMap.SimpleEntry<>(yml.toString(), value);
       }
     } catch (IOException e) {
-      throw new RuntimeException("Error writing resources");
+      throw new RuntimeException("Error writing resources", e);
     }
   }
 
@@ -130,7 +130,7 @@ public class AptWriter implements SessionWriter, WithProject {
         result.put(yml.getName(), yamlValue);
       }
     } catch (IOException e) {
-      throw new RuntimeException("Error writing resources");
+      throw new RuntimeException("Error writing resources", e);
     }
     return null;
   }

--- a/core/src/main/java/io/ap4k/processor/SimpleFileWriter.java
+++ b/core/src/main/java/io/ap4k/processor/SimpleFileWriter.java
@@ -68,7 +68,7 @@ public class SimpleFileWriter implements SessionWriter, WithProject {
         return new AbstractMap.SimpleEntry<>(yml.toString(), value);
       }
     } catch (IOException e) {
-      throw new RuntimeException("Error writing resources");
+      throw new RuntimeException("Error writing resources", e);
     }
   }
 
@@ -92,7 +92,7 @@ public class SimpleFileWriter implements SessionWriter, WithProject {
       }
 
     } catch (IOException e) {
-      throw new RuntimeException("Error writing resources");
+      throw new RuntimeException("Error writing resources", e);
     }
   }
 
@@ -134,7 +134,7 @@ public class SimpleFileWriter implements SessionWriter, WithProject {
 
       return result;
     } catch (IOException e) {
-      throw new RuntimeException("Error writing resources");
+      throw new RuntimeException("Error writing resources", e);
     }
   }
 }

--- a/core/src/main/java/io/ap4k/project/AptProjectFactory.java
+++ b/core/src/main/java/io/ap4k/project/AptProjectFactory.java
@@ -51,7 +51,7 @@ public class AptProjectFactory {
       f = environment.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", ".marker-" + UUID.randomUUID().toString());
       return FileProjectFactory.create(Paths.get(f.toUri()).toFile());
     } catch (IOException e) {
-      throw new RuntimeException("Failed to determine the project root!");
+      throw new RuntimeException("Failed to determine the project root!", e);
     } finally {
       if (f != null) {
         f.delete();

--- a/core/src/main/java/io/ap4k/project/MavenInfoReader.java
+++ b/core/src/main/java/io/ap4k/project/MavenInfoReader.java
@@ -73,11 +73,11 @@ public class MavenInfoReader implements BuildInfoReader {
       DocumentBuilder builder = factory.newDocumentBuilder();
       return builder.parse(pom.toFile());
     } catch (IOException e) {
-      throw new RuntimeException(("Failed to read: " + pom.toAbsolutePath()));
+      throw new RuntimeException(("Failed to read: " + pom.toAbsolutePath()), e);
     } catch (ParserConfigurationException e) {
-      throw new RuntimeException(("Failed to parse: " + pom.toAbsolutePath()));
+      throw new RuntimeException(("Failed to parse: " + pom.toAbsolutePath()), e);
     } catch (SAXException e) {
-      throw new RuntimeException(("Failed to parse: " + pom.toAbsolutePath()));
+      throw new RuntimeException(("Failed to parse: " + pom.toAbsolutePath()), e);
     }
   }
 

--- a/core/src/main/java/io/ap4k/utils/Serialization.java
+++ b/core/src/main/java/io/ap4k/utils/Serialization.java
@@ -258,7 +258,7 @@ public class Serialization {
       }
       return outputStream.toString();
     } catch (IOException e) {
-      throw new RuntimeException("Unable to read InputStream." + e);
+      throw new RuntimeException("Unable to read InputStream." , e);
     }
   }
 


### PR DESCRIPTION
 Don't swallow originating exception in catch blocks.
So, that we don't loose the stack trace info.

Process each config only once.

Why?

It seems that annotation processors are not allowed to open a resource twice.
If for any reason the compiler is triggered more than once (e.g. "Changes detected - recompiling the module!") configs are going to be added twice.

We need to make sure that even in that case each config is processed just once.